### PR TITLE
Update build syntax

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -6,12 +6,12 @@ pub fn build(b: *std.Build) void {
     const optimize = b.standardOptimizeOption(.{});
 
     // Make module available as dependency.
-    _ = b.addModule("wav", .{ .source_file = .{ .path = "src/wav.zig" } });
+    _ = b.addModule("wav", .{ .root_source_file = b.path("src/wav.zig") });
 
     const test_step = b.step("test", "Run library tests");
     inline for ([_][]const u8{ "src/sample.zig", "src/wav.zig" }) |test_file| {
         const t = b.addTest(.{
-            .root_source_file = .{ .path = test_file },
+            .root_source_file = b.path(test_file),
             .target = target,
             .optimize = optimize,
         });


### PR DESCRIPTION
To my knowledge, this PR updates some of the build.zig syntax so that it works with Zig's latest version (currently 0.14.0).

Ran into problems trying to build zig-wav. After applying the patch described here onto the cached build.zig, it worked -- there still seem to be some problems, but not with the building process itself.